### PR TITLE
Register blocks

### DIFF
--- a/R/register.R
+++ b/R/register.R
@@ -1,0 +1,46 @@
+register_extra_blocks <- function(pkgname) {
+  blockr::register_block(
+    constructor = code_transform_block,
+    name = "Code transform block",
+    description = "Use arbitrary R code to transform data",
+    classes = c("code_transform_block", "transform_block"),
+    input = "data.frame",
+    output = "data.frame"
+  )
+
+  blockr::register_block(
+    constructor = code_plot_block,
+    name = "Code plot block",
+    description = "Use arbitrary R code to plot data",
+    classes = c("code_plot_block", "transform_block"),
+    input = "data.frame",
+    output = "data.frame"
+  )
+
+  blockr::register_block(
+    constructor = summarize_expr_block,
+    name = "Summarize expression block",
+    description = "Use arbitrary R code to summarize data",
+    classes = c("summarize_expr_block", "transform_block"),
+    input = "data.frame",
+    output = "data.frame"
+  )
+
+  blockr::register_block(
+    constructor = filter_expr_block,
+    name = "Filter expression block",
+    description = "Use arbitrary R code to filter data",
+    classes = c("filter_expr_block", "transform_block"),
+    input = "data.frame",
+    output = "data.frame"
+  )
+
+  blockr::register_block(
+    constructor = admiral_dpc_block,
+    name = "Admiral DPC block",
+    description = "Admiral derive param computed block",
+    classes = c("admiral_dpc_block", "transform_block"),
+    input = "data.frame",
+    output = "data.frame"
+  )
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,4 @@
+.onLoad <- function(libname, pkgname) {
+  register_extra_blocks(pkgname)
+  invisible(NULL)
+}


### PR DESCRIPTION
This registers blocks, except the demo blocks, I do not think they are needed.

```r
available_blocks() |> names()                                                                                                    
[1] "admiral_dpc_block"    "code_plot_block"      "code_transform_block" "dataset_block"        "filter_block"        
[6] "filter_expr_block"    "select_block"         "summarize_block"      "summarize_expr_block"
```